### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ monitoring.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-service-management.svg
    :target: https://pypi.org/project/google-cloud-service-management/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-management.svg
@@ -85,4 +85,4 @@ Next Steps
    APIs that we cover.
 
 .. _Service Management API Product documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.