### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "servicemanagement",
     "name_pretty": "Service Management API",
     "product_documentation": "https://cloud.google.com/service-infrastructure/docs/overview/",
-    "client_documentation": "https://googleapis.dev/python/servicemanagement/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/servicemanagement/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ monitoring.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-management.svg
    :target: https://pypi.org/project/google-cloud-service-management/
 .. _Service Management API: https://cloud.google.com/service-infrastructure/docs/overview/
-.. _Client Library Documentation: https://googleapis.dev/python/servicemanagement/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicemanagement/latest
 .. _Product Documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.